### PR TITLE
Move Resources to Their Own Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ Be sure to read [How To submit your suggestion](./how-to/submit-your-suggestion.
 - [SheSharp Knowledge Hub](#shesharp-knowledge-hub)
   - [Introduction](#introduction)
   - [Suggesting a resource](#suggesting-a-resource)
-- [Table of Contents](#table-of-contents)
-- [Social Media](#social-media)
-  - [Instagram profiles](#instagram-profiles)
-  - [Linkedin profiles](#linkedin-profiles)
-  - [Organizations that help women and non-binary people break into tech](#organizations-that-help-women-and-non-binary-people-break-into-tech)
-- [Resources](#resources)
-  - [Randstad Housing](resources/randstad-housing.md)
+  - [Table of Contents](#table-of-contents)
+  - [Social Media](#social-media)
+    - [Instagram profiles](#instagram-profiles)
+    - [Linkedin profiles](#linkedin-profiles)
+  - [Resources](#resources)
 
 ## Social Media
 
@@ -44,10 +42,4 @@ Be sure to read [How To submit your suggestion](./how-to/submit-your-suggestion.
 ## Resources
 
 - [Randstad Housing](resources/randstad-housing.md)
-
-## Organizations that help women and non-binary people break into tech
-
-- [SheCodes](https://www.shecodes.io)
-- [Women Who Code](https://womenwhocode.com)
-- [Lesbians Who Tech](https://lesbianswhotech.org)
-- [Ada Developers Academy](https://adadevelopersacademy.org)
+- [Supportive Tech Organizations](resources/supportive-tech-orgs.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SheSharp knowledge hub
+# SheSharp Knowledge Hub
 
 ## Introduction
 
@@ -15,57 +15,35 @@ We invite as many contributions as possible. If you know of a resource that woul
 
 Be sure to read [How To submit your suggestion](./how-to/submit-your-suggestion.md)
 
-# Table of Contents
+## Table of Contents
 
-- [SheSharp knowledge hub](#shesharp-knowledge-hub)
+- [SheSharp Knowledge Hub](#shesharp-knowledge-hub)
   - [Introduction](#introduction)
   - [Suggesting a resource](#suggesting-a-resource)
 - [Table of Contents](#table-of-contents)
-- [Randstad Housing Resources](#randstad-housing-resources)
 - [Social Media](#social-media)
   - [Instagram profiles](#instagram-profiles)
   - [Linkedin profiles](#linkedin-profiles)
   - [Organizations that help women and non-binary people break into tech](#organizations-that-help-women-and-non-binary-people-break-into-tech)
+- [Resources](#resources)
+  - [Randstad Housing](resources/randstad-housing.md)
 
-# Randstad Housing Resources
-  Housing in the Netherlands can be tough, besides using our Slack channel to network with other home seekers/ potential flatmates, we've curated some resources to aid in the search for a rental home. Things to keep in mind when looking for a rental home:
-  - An energy label of C or higher is recommended.
-  - If subletting or renting a room/apt from an owner, check whether you can register at the address.
-  - Apartments usually come one of three ways: unfinished, unfurnished, or furnished.
-  - Unfinished apartments usually require the tenant to install flooring, light fixtures, and potentially appliances / a kitchen. They also tend to be cheaper. It is difficult to find a reliable handyman / contractor in the Netherlands, and this is especially true in Amsterdam.
-  - Unfurnished apartments have floors, sometimes ceiling lighting fixtures, and kitchen. It is "finished."
-  - Furnished apartments have the above as well as furniture owned by the landlord. They usually require a deposit for the furniture, and often landlords will not change the furniture. For example, if there is a giant dining table in a tiny studio apartment, do not expect that the landlord will change it once you move in.
+## Social Media
 
-  ### Housing search resources - Free
-  -[funda.nl](https://www.funda.nl)
-  Good for individuals with a higher budget, or for 2+ people seeking to share a flat. Free!
-  
-  -[pararius.nl](https://www.pararius.nl)
-  More lower cost options than Funda. Free!
-
-  -[Rentsy.nl](https://rentsy.nl/huurwoningen) An aggregate service that is free!
-
--[Kamernet.nl](https://kamernet.nl/en)
-Kamernet is mostly rooms, and it is free. Be cautious with the listings on this website, as there is little to no verification process. That being said, many student houses list upcoming vacancies here, and subletting opportunities are also listed here.
-
-### Housing search resources - paid
-
-  -[RentSlam.com](https://rentslam.com/)
-This is a **paid** aggregation service, starting at 30Euro / month, with discounts for longer subscriptions. It aggregates listings from all of the big websites, and some of the little ones, and sends those that fit your search criteria to your inbox. You can set up to 3 searches, for example for different cities.
-
-### Check your rent price
-Rental prices in the Randstad, and particularly Amsterdam, tend to be egregiously expensive and often illegal. You can use the [Huurcommissie site](https://checkjeprijs.huurcommissie.nl/en/onderwerpen/huurprijs-en-punten/nieuwe-huurprijscheck/rent-check-independent-living-space) to check your rental price against the legal limit.
-# Social Media
-
-## Instagram profiles
+### Instagram Profiles
 
 - [@developers_community](https://www.instagram.com/developers_community_._/)
 - [@marwane.dev](https://www.instagram.com/marwane.dev/)
 - [@programmer.nest](https://www.instagram.com/programmer.nest/)
 - [@webapp_creator](https://www.instagram.com/webapp_creator/)
 
-## Linkedin profiles 
+### Linkedin Profiles
+
 -[Christine Belzie](https://www.linkedin.com/in/christinebelzie)
+
+## Resources
+
+- [Randstad Housing](resources/randstad-housing.md)
 
 ## Organizations that help women and non-binary people break into tech
 
@@ -73,5 +51,3 @@ Rental prices in the Randstad, and particularly Amsterdam, tend to be egregiousl
 - [Women Who Code](https://womenwhocode.com)
 - [Lesbians Who Tech](https://lesbianswhotech.org)
 - [Ada Developers Academy](https://adadevelopersacademy.org)
-  
-  

--- a/resources/randstad-housing.md
+++ b/resources/randstad-housing.md
@@ -1,0 +1,38 @@
+# Randstad Housing Resources
+
+Housing in the Netherlands can be challenging. Besides using our Slack channel to network with other home seekers/ potential flatmates, we've curated some resources to aid in the search for a rental home. Things to keep in mind when looking for a rental home:
+
+- An energy label of C or higher is recommended.
+- If subletting or renting a room/apartment from an owner, check whether you can register at the address.
+- Apartments usually come in one of three ways: unfinished, unfurnished, or furnished.
+- Unfinished apartments usually require the tenant to install flooring, light fixtures, and potentially appliances / a kitchen. They also tend to be cheaper. Finding a reliable handyman/contractor in the Netherlands is difficult, and this is especially true in Amsterdam.
+- Unfurnished apartments have floors, sometimes ceiling lighting fixtures, and a kitchen. It is "finished."
+- Furnished apartments have the above as well as furniture owned by the landlord. They usually require a deposit for the furniture, and often, landlords will not change the furniture. For example, if a tiny studio apartment has a giant dining table, do not expect the landlord to change it once you move in.
+
+## Housing Search Resources — Free
+
+- [funda.nl](https://www.funda.nl)
+
+  Suitable for individuals with a higher budget or 2+ people seeking to share a flat. Free!
+
+- [pararius.nl](https://www.pararius.nl)
+
+  More lower cost options than Funda. Free!
+
+- [Rentsy.nl](https://rentsy.nl/huurwoningen)
+
+  Rentsy is an aggregate service that is free!
+
+- [Kamernet.nl](https://kamernet.nl/en)
+
+  Kamernet is mostly rooms, and it is free. Be cautious with the listings on this website, as there is little to no verification process. Many student houses list upcoming vacancies here, and subletting opportunities are also listed here.
+
+## Housing Search Resources — Paid
+
+- [RentSlam.com](https://rentslam.com/)
+
+  This **paid** aggregation service starts at 30 euros/month, with discounts for longer subscriptions. It aggregates listings from all the big websites and some little ones and sends those that fit your search criteria to your inbox. For example, you can set up to 3 searches for different cities.
+
+## Check Your Rent Price
+
+Rental prices in the Randstad, particularly Amsterdam, tend to be egregiously expensive and often illegal. You can use the [Huurcommissie site](https://checkjeprijs.huurcommissie.nl/en/onderwerpen/huurprijs-en-punten/nieuwe-huurprijscheck/rent-check-independent-living-space) to check your rental price against the legal limit.

--- a/resources/supportive-tech-orgs.md
+++ b/resources/supportive-tech-orgs.md
@@ -1,0 +1,8 @@
+# Supportive Tech Organizations
+
+You'll find the tech organizations that help women and non-binary people break into tech in the list below:
+
+- [SheCodes](https://www.shecodes.io)
+- [Women Who Code](https://womenwhocode.com)
+- [Lesbians Who Tech](https://lesbianswhotech.org)
+- [Ada Developers Academy](https://adadevelopersacademy.org)


### PR DESCRIPTION
## Description

Referring to issue #7, this PR moves resources from README to their own files.

## Changes

- Created "Resources" folder as a home for all resources.
- Created `randstad-housing.md` and `supportive-tech-orgs.md` files.
- Moved "Randstad Housing Resources" and "Organizations that help women and non-binary people break into tech" from README to the new files.
- Added a section called "Resources" in the README.
- Adjusted Table of Contents.
- Fixed headings to follow semantic HTML.
- Fixed and adjusted wordings.